### PR TITLE
Fixed IRI typo abis/rm ==> abis/brm

### DIFF
--- a/resources/models/abis/catalogue.ttl
+++ b/resources/models/abis/catalogue.ttl
@@ -13,7 +13,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:description "This is a third-level catalogue of the Biodiversity Data Repository containing models used in ABIS" ;
     schema:hasPart
         <https://linked.data.gov.au/def/nsl> ,
-        <https://linked.data.gov.au/def/abis/rm> ,
+        <https://linked.data.gov.au/def/abis/brm> ,
         <https://w3id.org/tern/ontologies/tern> ;
     schema:license <http://purl.org/NET/rdflicense/cc-by4.0> ;
     schema:name "ABIS Models Catalogue" ;


### PR DESCRIPTION
Fixed IRI ref:
<https://linked.data.gov.au/def/abis/rm> ==> <https://linked.data.gov.au/def/abis/brm>

Be good to confirm this model is supposed to be here - if unsure,  we should fix the typo so it can at least be tracked while that's reviewed.